### PR TITLE
Use `getopts` instead of positional command-line arguments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # windows-usb-image-sh
-Shell script for creating a UEFI Windows USB from Linux
 
-Usage:
-`sudo sh windows-usb-image.sh Win.iso /dev/disk/by-id/disk sha1_checksum`
+Shell script for copying disk images to block devices
+
+## Required arguments
+* -s    Source image file
+* -d    Destination block device (/dev/disk/by-id/)
+* -c    SHA1 checksum of source image file"
+* -C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)
+
+## Optional arguments
+* -b    Partition block size
+
+## Copy Mode
+Copy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.
+
+## DD Mode
+DD Mode will use "dd" to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -71,7 +71,7 @@ checksum_dd()
 	fi
 }
 
-while getopts "h:s:d:c:b" arg ; do
+while getopts "h:s:d:c:b:D" arg ; do
 	case $arg in
 		h)
 			usage
@@ -87,6 +87,9 @@ while getopts "h:s:d:c:b" arg ; do
 			;;
 		b)
 			BLOCK_SIZE=$OPTARG
+			;;
+		D)
+			DD=$OPTARG
 			;;
 		*)
 			usage

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -128,21 +128,19 @@ dd_checksum()
 	if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB has passed the checksum
 		exit 0
+	elif [ -z "$BLOCK_SIZE" ] ; then
+		dd if="$ISO" of="$DISK"
 	else
-		if [ -z "$BLOCK_SIZE" ] ; then
-			dd if="$ISO" of="$DISK" count=1
-		else
-			dd if="$ISO" of="$DISK" bs="$BLOCK_SIZE" count=1
-		fi
-		if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
-				echo The USB has passed the checksum
-				udisksctl unmount -b "$DISK" || true
-				exit 0
-			else
-				echo The USB has failed the checksum
-				udisksctl unmount -b "$DISK" || true
-				exit 1
-		fi
+			dd if="$ISO" of="$DISK" bs="$BLOCK_SIZE"
+	fi
+	if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
+		echo The USB has passed the checksum
+		udisksctl unmount -b "$DISK" || true
+		exit 0
+	else
+		echo The USB has failed the checksum
+		udisksctl unmount -b "$DISK" || true
+		exit 1
 	fi
 }
 

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -27,6 +27,7 @@ iso_checksum()
 cp_checksum()
 {
 	unmount
+	iso_checksum
 
 	echo Partitioning the USB
 	(
@@ -122,6 +123,7 @@ windows()
 dd_checksum()
 {
 	unmount
+	iso_checksum
 
 	if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB has passed the checksum
@@ -131,7 +133,8 @@ dd_checksum()
 			dd if="$ISO" of="$DISK" count=1
 		else
 			dd if="$ISO" of="$DISK" bs="$BLOCK_SIZE" count=1
-			if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
+		fi
+		if [ "$(head -c "$(stat -c "%s" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 				echo The USB has passed the checksum
 				udisksctl unmount -b "$DISK" || true
 				exit 0
@@ -139,7 +142,6 @@ dd_checksum()
 				echo The USB has failed the checksum
 				udisksctl unmount -b "$DISK" || true
 				exit 1
-			fi
 		fi
 	fi
 }

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -1,12 +1,9 @@
 #!/bin/sh -e
 
-ISO=$1
-DISK=$2
-CHECKSUM=$3
-BLOCK_SIZE=$4
-DD=$5
-
-CHECKSUM=$(echo "$CHECKSUM" | awk '{print tolower($0)}' )
+usage()
+{
+	echo "Usage: $0 -s <iso file> -d <destination block device> -c <iso sha1 checksum> [-b <partiton block size>] [--dd <run in DD mode>] [-h <help>]"
+}
 
 uefi()
 {
@@ -73,6 +70,31 @@ checksum_dd()
 		fi
 	fi
 }
+
+while getopts "h:s:d:c:b" arg ; do
+	case $arg in
+		h)
+			usage
+			;;
+		s)
+			ISO=$OPTARG
+			;;
+		d)
+			DISK=$OPTARG
+			;;
+		c)
+			CHECKSUM=$OPTARG
+			;;
+		b)
+			BLOCK_SIZE=$OPTARG
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+CHECKSUM=$(echo "$CHECKSUM" | awk '{print tolower($0)}')
 
 if [ "$(sha1sum "$ISO" | awk '{print $1}')" = "$CHECKSUM" ] ; then
 	echo The ISO file passed the checksum

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -2,7 +2,22 @@
 
 usage()
 {
-	echo "Usage: $0 -s <iso file> -d <destination block device> -c <iso sha1 checksum> [-b <partiton block size>] [--dd <run in DD mode>] [-h <help>]"
+	echo 'windows-usb-image-sh
+
+	Required arguments:
+	-s    Source image file
+	-d    Destination block device (/dev/disk/by-id/)
+	-c    SHA1 checksum of source image file"
+	-C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)
+
+	Optional arguments:
+	-b    Partition block size
+
+	Copy Mode:
+	Copy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.
+
+	DD Mode:
+	DD Mode will use "dd" to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.'
 	exit 0
 }
 

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -4,20 +4,22 @@ usage()
 {
 	echo 'windows-usb-image-sh
 
-	Required arguments:
-	-s    Source image file
-	-d    Destination block device (/dev/disk/by-id/)
-	-c    SHA1 checksum of source image file"
-	-C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)
+Shell script for copying disk images to block devices
 
-	Optional arguments:
-	-b    Partition block size
+Required arguments:
+-s    Source image file
+-d    Destination block device (/dev/disk/by-id/)
+-c    SHA1 checksum of source image file"
+-C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)
 
-	Copy Mode:
-	Copy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.
+Optional arguments:
+-b    Partition block size
 
-	DD Mode:
-	DD Mode will use "dd" to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.'
+Copy Mode:
+Copy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.
+
+DD Mode:
+DD Mode will use "dd" to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.'
 	exit 0
 }
 


### PR DESCRIPTION
Use `getopts` instead of positional command-line arguments as they are more reliable, and update the built-in help to reflect these changes.