### PR TITLE
Fail the script if copying UEFI:NTFS fails 

### DIFF
--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -113,11 +113,11 @@ uefi()
 {
 	if [ -z "$BLOCK_SIZE" ] ; then
 		echo Copying UEFI:NTFS
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART"
+		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
 		rm "$UEFI_NTFS"
 	else
 		echo Copying UEFI:NTFS
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE"
+		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
 		rm "$UEFI_NTFS"
 	fi
 }

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -142,14 +142,21 @@ windows()
 		rm "$CHECKSUM_FILE_WINDOWS"
 		cd "$CURRENT_PWD"
 		echo Unmounting the Windows partition
+		PASS=1
 	else
 		echo The Windows partition failed the checksum
 		rm "$CHECKSUM_FILE_WINDOWS"
 		cd "$CURRENT_PWD"
 		echo Unmounting the Windows partition
+		PASS=0
 	fi
 	umount "$WINDOWS"
 	rmdir "$WINDOWS"
+	if [ "$PASS" = 1 ] ; then
+		exit 0
+	else
+		exit 1
+	fi
 }
 
 dd_checksum()
@@ -205,3 +212,5 @@ while getopts "h:s:d:c:b:CD" arg ; do
 			;;
 	esac
 done
+
+usage


### PR DESCRIPTION
Since the USB won't be bootable if copying UEFI:NTFS fails, there is no point in continuing the script if failure has occurred here