### PR TITLE
Don't add the `VCS` tag to EL6 builds

### DIFF
--- a/windows-usb-image-sh.spec.rpkg
+++ b/windows-usb-image-sh.spec.rpkg
@@ -5,7 +5,9 @@ Summary: Bash script for copying disk images to block devices
 
 License: GPLv3+
 URL:     https://github.com/SocMinarch/windows-usb-image-sh
+%if ! %{el6}
 VCS:     {{{ git_dir_vcs }}}
+%endif
 
 Source:  {{{ git_dir_pack }}}
 


### PR DESCRIPTION
Fixes https://github.com/SocMinarch/windows-usb-image-sh/issues/18