### PR TITLE
Validate the UEFI:NTFS partition after it has been copied

### DIFF
--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -77,7 +77,7 @@ cp_checksum()
 		echo n
 		echo
 		echo
-		echo +1K
+		echo +512K
 		echo t
 		echo 1
 		echo n

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -123,15 +123,19 @@ cp_checksum()
 
 uefi()
 {
+	echo Copying UEFI:NTFS
+	UEFI_NTFS_CHECKSUM=$(sha1sum "$UEFI_NTFS" | awk '{print $1}')
 	if [ -z "$BLOCK_SIZE" ] ; then
-		echo Copying UEFI:NTFS
 		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
-		rm "$UEFI_NTFS"
 	else
-		echo Copying UEFI:NTFS
 		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
-		rm "$UEFI_NTFS"
 	fi
+	if [ "$(head -c "$(stat -c "%s" "$UEFI_NTFS")" "$DISK$UEFI_PART" | sha1sum | awk '{print $1}')" = "$UEFI_NTFS_CHECKSUM" ] ; then
+		echo The UEFI partition passed the checksum
+	else
+		echo The UEFI partition failed the checksum
+	fi
+	rm "$UEFI_NTFS"
 }
 
 windows()

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -126,9 +126,9 @@ uefi()
 	echo Copying UEFI:NTFS
 	UEFI_NTFS_CHECKSUM=$(sha1sum "$UEFI_NTFS" | awk '{print $1}')
 	if [ -z "$BLOCK_SIZE" ] ; then
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
+		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" || echo Failed to copy UEFI:NTFS to the UEFI partition
 	else
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE" || echo Failed to copy UEFI:NTFS to the UEFI partition && exit 1
+		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE" || echo Failed to copy UEFI:NTFS to the UEFI partition
 	fi
 	if [ "$(head -c "$(stat -c "%s" "$UEFI_NTFS")" "$DISK$UEFI_PART" | sha1sum | awk '{print $1}')" = "$UEFI_NTFS_CHECKSUM" ] ; then
 		echo The UEFI partition passed the checksum


### PR DESCRIPTION
- Validate the UEFI:NTFS partition after it has been copied
- Fix an issue where the UEFI:NTFS partition was to small for the image
- Don't exit the script if copying UEFI:NTFS fails
- Reduce code duplication