### PR TITLE
Support Copy Mode on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Bash script for copying Windows ISO images (or any ISO) to block devices
 * `-b`    Partition block size
 
 ## Copy Mode
-Copy Mode will format the destination block device and create a FAT32 partition on it. This partition contains the source image file contents. The Windows `install.wim` file will be split into blocks of 1000MB to avoid FAT32 file size limitations.
+Copy Mode will format the destination block device with an MBR partition table and create a FAT32 partition on it. This partition contains the source image file contents. The Windows `install.wim` file will be split into blocks of 1000MB to avoid FAT32 file size limitations.
+
+This USB should be compatible with both BIOS and UEFI.
 
 ## DD Mode
 DD Mode will use `dd` to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # windows-usb-image-sh
 
-Bash script for copying disk images to block devices
+Bash script for copying Windows ISO images (or any ISO) to block devices
 
 ## RPM build status
 
@@ -10,13 +10,13 @@ Bash script for copying disk images to block devices
 * `-s`    Source image file
 * `-d`    Destination block device
 * `-c`    SHA1 checksum of source image file
-* `-C|-D` Specify whether to use Copy Mode (`-C`) (Linux only) or DD Mode (`-D`)
+* `-C|-D` Specify whether to use Copy Mode (`-C`) or DD Mode (`-D`)
 
 ## Optional arguments
 * `-b`    Partition block size
 
-## Copy Mode (Linux only)
-Copy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.
+## Copy Mode
+Copy Mode will format the destination block device and create a FAT32 partition on it. This partition contains the source image file contents. The Windows `install.wim` file will be split into blocks of 1000MB to avoid FAT32 file size limitations.
 
 ## DD Mode
 DD Mode will use `dd` to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.

--- a/windows-usb-image-sh.spec.rpkg
+++ b/windows-usb-image-sh.spec.rpkg
@@ -11,6 +11,8 @@ VCS:     {{{ git_dir_vcs }}}
 
 Source:  {{{ git_dir_pack }}}
 
+Requires: rsync
+
 BuildArch: noarch
 
 %description

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -96,17 +96,18 @@ cp_checksum()
 		PART_MOUNT="/Volumes/WIN/"
 	else
 		(
-			echo g
+			echo o
 			echo n
 			echo
 			echo
-			echo 
+			echo
+			echo
 			echo t
-			echo 1
-			echo 1
+			echo ef
+			echo a
 			echo w
 		) | fdisk "$DISK" || partprobe && sleep 3
-		mkfs.fat -F F32 "$DISK""$PART"
+		mkfs.fat -F 32 "$DISK""$PART"
 		PART_MOUNT=$(mktemp -d)
 		mount -o loop "$DISK""$PART" "$PART_MOUNT"
 	fi

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -93,6 +93,16 @@ cp_checksum()
 	echo Formatting the USB drive as FAT32
 	if [ "$UNAME" = "Darwin" ] ; then
 		diskutil eraseDisk FAT32 WIN MBR "$DISK"
+		(
+			echo edit 1
+			echo EF
+			echo
+			echo
+			echo
+			echo flag 1
+			echo quit
+			echo y
+		) | fdisk -e "$DISK"
 		PART_MOUNT="/Volumes/WIN/"
 	else
 		(

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-USAGE='windows-usb-image-sh\n\nBash script for copying disk images to block devices\n\nRequired arguments:\n-s    Source image file\n-d    Destination block device (/dev/disk/by-id/)\n-c    SHA1 checksum of source image file\n-C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)\n\nOptional arguments:\n-b    Partition block size\n-h    Show help\n-H    Show full help\n'
-FULL_USAGE='\nCopy Mode (Linux only):\nCopy Mode will create a 512KB FAT32 partition at the start of the block device, and an NTFS partition in the remaining space. The FAT32 partition contains the UEFI:NTFS bootloader, and the NTFS partition contains the source image file contents.\n\nDD Mode:\nDD Mode will use "dd" to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.\n'
+USAGE='windows-usb-image-sh\n\nBash script for copying Windows ISO images (or any ISO) to block devices\n\nRequired arguments:\n-s    Source image file\n-d    Destination block device (/dev/disk/by-id/)\n-c    SHA1 checksum of source image file\n-C|-D Specify whether to use Copy Mode (-C) or DD Mode (-D)\n\nOptional arguments:\n-b    Partition block size\n-h    Show help\n-H    Show full help\n'
+FULL_USAGE='\nCopy Mode:\nCopy Mode will format the destination block device with an MBR partition table and create a FAT32 partition on it. This partition contains the source image file contents. The Windows `install.wim` file will be split into blocks of 1000MB to avoid FAT32 file size limitations.\n\nThis USB should be compatible with both BIOS and UEFI.\n\nDD Mode:\nDD Mode will use `dd` to clone the source image onto the destination block device. Copying will not be performed if the destination block devices checksum is the same as that of the source images.\n'
 
 #shellcheck disable=SC2059
 usage()

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -23,13 +23,17 @@ os()
 	UNAME="$(uname -s)"	
 
 	if [ "$UNAME" = "Linux" ] ; then
-		UNMOUNT=udisksctl unmount -b
+		UNMOUNT=udisksctl
+		UNMOUNT_ARGS=unmount -b
+
 		STAT=-c "%s"
 	elif [ "$UNAME" = "BSD" ] || [ "$UNAME" = "Darwin" ] ; then
 		if [ "$UNAME" = "Darwin" ] ; then
-			UNMOUNT=diskutil unmount
+			UNMOUNT=diskutil
+			UNMOUNT_ARGS=unmountDisk
 		else
-			UNMOUNT=udisksctl unmount -b
+			UNMOUNT=udisksctl
+			UNMOUNT_ARGS=unmount -b
 		fi
 		STAT=-f%z
 	else
@@ -41,7 +45,7 @@ os()
 unmount()
 {
 	echo Unmounting the USB
-	"$UNMOUNT" "$DISK"
+	"$UNMOUNT" "$UNMOUNT_ARGS" "$DISK"
 }
 
 iso_checksum()
@@ -59,17 +63,13 @@ iso_checksum()
 disk_mode()
 {
 	if [[ "$DISK" = /dev/disk/by-id/* ]] ; then
-		UEFI_PART=-part1
-		NTFS_PART=-part2
+		PART=-part1
 	elif [[ "$DISK" = /dev/sd* ]] || [[ "$DISK" = /dev/hd* ]] ; then
-		UEFI_PART=1
-		NTFS_PART=2
+		PART=1
 	elif [[ "$DISK" = /dev/nvme* ]] ; then
-		UEFI_PART=p1
-		NTFS_PART=p2
+		PART=p1
 	elif [[ "$DISK" = /dev/disk* ]] ; then
-		UEFI_PART=s1
-		NTFS_PART=s2
+		PART=s1
 	else
 		echo Unknown block device path
 		exit 1
@@ -79,119 +79,53 @@ disk_mode()
 cp_checksum()
 {
 	os
-
-	if ! [ "$UNAME" = "Linux" ] ; then
-		echo "Copy Mode is currently only supported under Linux"
-		exit 1
-	fi
-
 	unmount
 	iso_checksum
-	disk_mode
-
-	echo Partitioning the USB
-	(
-		echo g
-		echo n
-		echo
-		echo
-		echo +512K
-		echo t
-		echo 1
-		echo n
-		echo
-		echo
-		echo
-		echo t
-		echo 2
-		echo 1
-		echo w
-	) | fdisk "$DISK" || partprobe && sleep 3
-
-	echo Downloading UEFI:NTFS
-	UEFI_NTFS="$(mktemp)"
-	curl https://github.com/pbatard/rufus/raw/master/res/uefi/uefi-ntfs.img -o "$UEFI_NTFS"
-
-	if [ -z "$BLOCK_SIZE" ] ; then
-		echo Creating the Windows partition
-		mkfs.ntfs -Q "$DISK$NTFS_PART"
-	else
-		echo Creating the Windows partition
-		mkfs.ntfs -Q -s "$BLOCK_SIZE" "$DISK$NTFS_PART"
-	fi
 
 	echo Mounting the Windows ISO
-	LOOP=$(mktemp -d)
-	mount "$ISO" -o loop,ro "$LOOP"
+	if ! [ "$UNAME" = "Darwin" ] ; then
+		LOOP=$(mktemp -d)
+		mount "$ISO" -o loop,ro "$LOOP"
+	else
+		LOOP=$(hdiutil mount "$ISO" | awk '{ print $2 }')
+	fi
 
-	CURRENT_PWD=$(pwd)
+	echo Formatting the USB drive as FAT32
+	if [ "$UNAME" = "Darwin" ] ; then
+		diskutil eraseDisk FAT32 WIN10 MBR "$DISK"
+		PART_MOUNT=/Volumes/WIN10/
+	else
+		(
+			echo g
+			echo n
+			echo
+			echo
+			echo t
+			echo 2
+			echo 1
+			echo w
+		) | fdisk "$DISK" || partprobe && sleep 3
+		PART_MOUNT=$(mktemp -d)
+		mount -o loop "$DISK""$PART" "$PART_MOUNT"
+	fi
 
-	uefi &
-	windows &
-	wait
+	echo Copying the Windows 10 ISO files
+	rsync -qah --exclude=sources/install.wim "$LOOP"/* "$PART_MOUNT"
 
+	echo Splitting the Windows 10 install.wim file
+	wimsplit "$LOOP"/sources/install.wim /Volumes/WIN10/sources/install.swm 1000 --check
+
+	unmount || true
+	
 	echo Unmounting the Windows ISO
 	umount "$LOOP"
 
-	unmount || true
-
-	echo Cleaning up
-	rmdir "$LOOP"
-
+	if [ "$UNAME" = "Linux" ] ; then
+		echo Cleaning up
+		rmdir "$LOOP" "$PART_MOUNT" 
+	fi
+	
 	exit 0
-}
-
-uefi()
-{
-	os
-
-	echo Copying UEFI:NTFS
-	UEFI_NTFS_CHECKSUM=$(sha1sum "$UEFI_NTFS" | awk '{print $1}')
-	if [ -z "$BLOCK_SIZE" ] ; then
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" || echo Failed to copy UEFI:NTFS to the UEFI partition
-	else
-		dd if="$UEFI_NTFS" of="$DISK$UEFI_PART" bs="$BLOCK_SIZE" || echo Failed to copy UEFI:NTFS to the UEFI partition
-	fi
-	if [ "$(head -c "$(stat "$STAT" "$UEFI_NTFS")" "$DISK$UEFI_PART" | sha1sum | awk '{print $1}')" = "$UEFI_NTFS_CHECKSUM" ] ; then
-		echo The UEFI partition passed the checksum
-	else
-		echo The UEFI partition failed the checksum
-	fi
-	rm "$UEFI_NTFS"
-}
-
-windows()
-{
-	echo Generating checksums for the Windows partition files
-	CHECKSUM_FILE_WINDOWS=$(mktemp)
-	cd "$LOOP"
-	find . -type f -exec sha1sum {} \; >> "$CHECKSUM_FILE_WINDOWS"
-
-	echo Mounting the Windows partition
-	WINDOWS=$(mktemp -d)
-	mount "$DISK$NTFS_PART" "$WINDOWS"
-
-	echo Copying the Windows partition files
-	cp -r "$LOOP"/* "$WINDOWS"
-	cd "$WINDOWS"
-	echo Validating the Windows partition files
-	if sha1sum --status -c "$CHECKSUM_FILE_WINDOWS" ; then
-		echo The Windows partition passed the checksum
-	else
-		FAILED=true
-		echo The Windows partition failed the checksum
-	fi
-	rm "$CHECKSUM_FILE_WINDOWS"
-	cd "$CURRENT_PWD"
-	echo Unmounting the Windows partition
-	umount "$WINDOWS"
-	rmdir "$WINDOWS"
-
-	if ! [ -z "$FAILED" ] ; then
-		exit 0
-	else
-		exit 1
-	fi
 }
 
 dd_checksum()

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -120,7 +120,7 @@ cp_checksum()
 	echo Unmounting the Windows ISO
 	umount "$LOOP"
 
-	if [ "$UNAME" = "Linux" ] ; then
+	if ! [ "$UNAME" = "Darwin" ] ; then
 		echo Cleaning up
 		rmdir "$LOOP" "$PART_MOUNT" 
 	fi

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -135,7 +135,7 @@ dd_checksum()
 	disk_mode
 	os
 
-	if [ "$(head -c "$(stat $STAT "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
+	if [ "$(head -c "$(stat "$STAT" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB already matches the ISO
 		exit 0
 	elif [ -z "$BLOCK_SIZE" ] ; then
@@ -144,7 +144,7 @@ dd_checksum()
 		dd if="$ISO" of="$DISK" bs="$BLOCK_SIZE"
 	fi
 
-	if [ "$(head -c "$(stat $STAT "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
+	if [ "$(head -c "$(stat "$STAT" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB has passed the checksum
 		unmount || true
 		exit 0

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -76,8 +76,18 @@ disk_mode()
 	fi
 }
 
+check_if_writeable()
+{
+	if ! [ -w "$DISK" ] ; then
+		echo Cannot write to "$DISK": Permission denied
+		exit 1
+	fi
+}
+
 cp_checksum()
 {
+	disk_mode
+	check_if_writeable
 	os
 	unmount
 	iso_checksum
@@ -160,10 +170,11 @@ cp_checksum()
 
 dd_checksum()
 {
+	disk_mode
+	check_if_writeable
+	os
 	unmount
 	iso_checksum
-	disk_mode
-	os
 
 	if [ "$(head -c "$(stat "$STAT" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB already matches the ISO

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -139,7 +139,11 @@ cp_checksum()
 		rmdir "$LOOP" "$PART_MOUNT" 
 	fi
 	
+	if ! [ -z "$FAILED" ] ; then
 	exit 0
+	else
+		exit 1
+	fi
 }
 
 dd_checksum()

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -92,8 +92,8 @@ cp_checksum()
 
 	echo Formatting the USB drive as FAT32
 	if [ "$UNAME" = "Darwin" ] ; then
-		diskutil eraseDisk FAT32 WIN10 MBR "$DISK"
-		PART_MOUNT=/Volumes/WIN10/
+		diskutil eraseDisk FAT32 WIN MBR "$DISK"
+		PART_MOUNT="/Volumes/WIN/"
 	else
 		(
 			echo g

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -139,7 +139,7 @@ cp_checksum()
 	echo Copying the Windows ISO files
 	rsync -qah --exclude=sources/install.wim "$LOOP"/* "$PART_MOUNT"
 	
-	echo Splitting the Windows 10 install.wim file
+	echo Splitting the Windows `install.wim` file
 	wimsplit "$LOOP"/sources/install.wim /Volumes/WIN/sources/install.swm 1000 --check
 
 	echo Validating the Windows partition files
@@ -176,15 +176,19 @@ dd_checksum()
 	unmount
 	iso_checksum
 
+	echo Checking if the USB already matches the ISO
 	if [ "$(head -c "$(stat "$STAT" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB already matches the ISO
 		exit 0
 	elif [ -z "$BLOCK_SIZE" ] ; then
+		echo Writing the ISO to the USB
 		dd if="$ISO" of="$DISK"
 	else
+		echo Writing the ISO to the USB
 		dd if="$ISO" of="$DISK" bs="$BLOCK_SIZE"
 	fi
 
+	echo Checking the USB integrity
 	if [ "$(head -c "$(stat "$STAT" "$ISO")" "$DISK" | sha1sum | awk '{print $1}')" = "$CHECKSUM" ] ; then
 		echo The USB has passed the checksum
 		unmount || true

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -105,6 +105,7 @@ cp_checksum()
 			echo 1
 			echo w
 		) | fdisk "$DISK" || partprobe && sleep 3
+		mkfs.fat -F F32 "$DISK""$PART"
 		PART_MOUNT=$(mktemp -d)
 		mount -o loop "$DISK""$PART" "$PART_MOUNT"
 	fi

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -100,8 +100,9 @@ cp_checksum()
 			echo n
 			echo
 			echo
+			echo 
 			echo t
-			echo 2
+			echo 1
 			echo 1
 			echo w
 		) | fdisk "$DISK" || partprobe && sleep 3

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -23,17 +23,17 @@ os()
 	UNAME="$(uname -s)"	
 
 	if [ "$UNAME" = "Linux" ] ; then
-		UNMOUNT=udisksctl
-		UNMOUNT_ARGS=unmount -b
+		UNMOUNT="udisksctl"
+		UNMOUNT_ARGS="unmount -b"
 
 		STAT=-c "%s"
 	elif [ "$UNAME" = "BSD" ] || [ "$UNAME" = "Darwin" ] ; then
 		if [ "$UNAME" = "Darwin" ] ; then
-			UNMOUNT=diskutil
-			UNMOUNT_ARGS=unmountDisk
+			UNMOUNT="diskutil"
+			UNMOUNT_ARGS="unmountDisk"
 		else
-			UNMOUNT=udisksctl
-			UNMOUNT_ARGS=unmount -b
+			UNMOUNT="udisksctl"
+			UNMOUNT_ARGS="unmount -b"
 		fi
 		STAT=-f%z
 	else

--- a/windows-usb-image.sh
+++ b/windows-usb-image.sh
@@ -117,7 +117,7 @@ cp_checksum()
 
 	echo Copying the Windows ISO files
 	rsync -qah --exclude=sources/install.wim "$LOOP"/* "$PART_MOUNT"
-
+	
 	echo Splitting the Windows 10 install.wim file
 	wimsplit "$LOOP"/sources/install.wim /Volumes/WIN/sources/install.swm 1000 --check
 
@@ -141,7 +141,7 @@ cp_checksum()
 	fi
 	
 	if ! [ -z "$FAILED" ] ; then
-	exit 0
+		exit 0
 	else
 		exit 1
 	fi


### PR DESCRIPTION
- Support Copy Mode on macOS
- Windows images are now written to a single FAT32 partition
- The Windows `install.wim` file is split into blocks of 1000MB by `wimsplit` to avoid the FAT32 4GB file size limitation
- This removes the need for `UEFI:NTFS`
- Requires `rsync` to selectively copy Windows ISO files to the new partition

TODO:

- [ ] Confirm Linux support isn't broken
- [ ] (OPTIONAL) Confirm BSD support